### PR TITLE
Update Workspace Configuration and Volumes

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,1 @@
+config/README.md

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,9 +45,12 @@ WORKDIR $HOME
 COPY --chown=${USERNAME}:${USERNAME} config .
 
 # Update .bashrc
-RUN ./update-bashrc.sh
+RUN chmod +x update-bashrc.sh \
+    && /bin/bash -c ${HOME}/update-bashrc.sh \
+    && rm ${HOME}/update-bashrc.sh
 
 ENV WORKSPACE_DIR=/workspace
+ENV OS161_DEPENDENCIES_DIR=/os161_dependencies
 ENV OS161_SRC=$WORKSPACE_DIR/os161/src
 WORKDIR $WORKSPACE_DIR
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd --gid $GID $USERNAME \
 
 ENV DEBIAN_FRONTEND=
 
-# Set environment variables
+# Set environment variables. If you change these, also update docker-compose.yml accordingly.
 ENV WORKSPACE_DIR=/workspace
 ENV OS161_DEPENDENCIES_DIR=/os161_dependencies
 ENV OS161_SRC=$WORKSPACE_DIR/os161/src

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,6 +37,11 @@ RUN groupadd --gid $GID $USERNAME \
 
 ENV DEBIAN_FRONTEND=
 
+# Set environment variables
+ENV WORKSPACE_DIR=/workspace
+ENV OS161_DEPENDENCIES_DIR=/os161_dependencies
+ENV OS161_SRC=$WORKSPACE_DIR/os161/src
+
 # Set new user as the default user for the container
 USER $USERNAME
 
@@ -48,11 +53,6 @@ COPY --chown=${USERNAME}:${USERNAME} config .
 RUN chmod +x update-bashrc.sh \
     && /bin/bash -c ${HOME}/update-bashrc.sh \
     && rm ${HOME}/update-bashrc.sh
-
-ENV WORKSPACE_DIR=/workspace
-ENV OS161_DEPENDENCIES_DIR=/os161_dependencies
-ENV OS161_SRC=$WORKSPACE_DIR/os161/src
-WORKDIR $WORKSPACE_DIR
 
 # Set the default command to open a bash terminal
 CMD ["/bin/bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,6 +40,13 @@ ENV DEBIAN_FRONTEND=
 # Set new user as the default user for the container
 USER $USERNAME
 
+# Copy config contents into home directory
+WORKDIR $HOME
+COPY --chown=${USERNAME}:${USERNAME} config .
+
+# Update .bashrc
+RUN ./update-bashrc.sh
+
 ENV WORKSPACE_DIR=/workspace
 ENV OS161_SRC=$WORKSPACE_DIR/os161/src
 WORKDIR $WORKSPACE_DIR

--- a/.devcontainer/config/.gdbinit
+++ b/.devcontainer/config/.gdbinit
@@ -1,0 +1,86 @@
+directory /workspace/os161/src/kern/compile/DUMBVM
+directory /workspace/os161/src/kern/compile/SYNCHPROBS
+
+define db 
+target remote unix:.sockets/gdb 
+end
+
+# gdb scripts for dumping resizeable arrays.
+#
+# Unfortunately, there does not seem to be a way to do this without
+# cutting and pasting for every type.
+
+define plainarray
+    set $n = $arg0.num
+    set $i = 0
+    printf "%u items\n", $n
+    while ($i < $n)
+	print $arg0.v[$i]
+	set $i++
+    end
+end
+document plainarray
+Print a plain (untyped) resizeable array.
+Usage: plainarray myarray
+end
+
+define array
+    set $n = $arg0.arr.num
+    set $i = 0
+    printf "%u items\n", $n
+    while ($i < $n)
+	print $arg0.arr.v[$i]
+	set $i++
+    end
+end
+document array
+Print the pointers in a typed resizeable array.
+(Use plainarray for an untyped resizeable array.)
+Usage: array allcpus
+end
+
+define cpuarray
+    set $n = $arg0.arr.num
+    set $i = 0
+    printf "%u cpus\n", $n
+    while ($i < $n)
+	printf "cpu %u:\n", $i
+	print *(struct cpu *)($arg0.arr.v[$i])
+	set $i++
+    end
+end
+document cpuarray
+Print an array of struct cpu.
+Usage: cpuarray allcpus
+end
+
+define threadarray
+    set $n = $arg0.arr.num
+    set $i = 0
+    printf "%u threads\n", $n
+    while ($i < $n)
+	printf "thread %u:\n", $i
+	print *(struct thread *)($arg0.arr.v[$i])
+	set $i++
+    end
+end
+document threadarray
+Print an array of struct thread.
+Usage: threadarray curproc->p_threads
+end
+
+define vnodearray
+    set $n = $arg0.arr.num
+    set $i = 0
+    printf "%u vnodes\n", $n
+    while ($i < $n)
+	printf "vnode %u:\n", $i
+	print *(struct vnode *)($arg0.arr.v[$i])
+	set $i++
+    end
+end
+document vnodearray
+Print an array of struct vnode.
+Usage: vnodearray sfs->sfs_vnodes
+end
+

--- a/.devcontainer/config/README.md
+++ b/.devcontainer/config/README.md
@@ -1,0 +1,37 @@
+# Devcontainer Configuration
+
+## Purpose
+
+The `.devcontainer/config` directory contains configuration files that are copied into the home
+directory of the docker container.
+
+## How to Configure the Devcontainer
+
+Be sure to follow the instructions here to configure files in the home directory inside the devcontainer.
+Creating and/or editing any files within `/home/osdev` inside the devcontainer will not work because the home
+directory is not persisted as part of a docker volume. You will lose any changes upon stopping the container.
+
+When any changes are made in the `config` directory, you will need to rebuild the docker container with
+the VS Code command `Dev Containers: Rebuild and Reopen in Container`.
+
+### Update the .bashrc
+
+The `update-bashrc.sh` script is responsible for updating `~/.bashrc` inside the devcontainer. If you
+want to update the bashrc inside the devcontainer, edit the script to do so.
+
+For example, if you want to add `echo "Hello World!"` inside the bashrc, the following line should be
+added inside the `update-bashrc.sh` script:
+
+```bash
+add_line_to_bashrc 'echo "Hello World!"'
+```
+
+### Add or Edit Dotfiles
+
+Add your own dotfiles to the devcontainer simply by dropping them inside the `config` directory and
+rebuilding the devcontainer. Likewise for editing dotfiles.
+
+### Sys161 Config File
+
+The `sys161.conf` file is copied to `/home/osdev`. It will automatically be copied to `$WORKSPACE_DIR/os161/root`
+during the setup process. If a configuration file already exists inside the root directory, it will not be overridden.

--- a/.devcontainer/config/README.md
+++ b/.devcontainer/config/README.md
@@ -3,16 +3,19 @@
 ## Purpose
 
 The `.devcontainer/config` directory contains configuration files that are copied into the home
-directory of the docker container.
+directory of the docker container. You may place your own dotfiles here to use them inside
+the devcontainer. Instructions are below.
 
 ## How to Configure the Devcontainer
 
 Be sure to follow the instructions here to configure files in the home directory inside the devcontainer.
 Creating and/or editing any files within `/home/osdev` inside the devcontainer will not work because the home
-directory is not persisted as part of a docker volume. You will lose any changes upon stopping the container.
+directory is not persisted as part of a docker volume. It would work temporarily, but you will lose any changes
+upon stopping the container.
 
 When any changes are made in the `config` directory, you will need to rebuild the docker container with
-the VS Code command `Dev Containers: Rebuild and Reopen in Container`.
+the VS Code command `Dev Containers: Rebuild and Reopen in Container`. Observe that your dotfiles are
+now populated in `/home/osdev`.
 
 ### Update the .bashrc
 
@@ -33,5 +36,6 @@ rebuilding the devcontainer. Likewise for editing dotfiles.
 
 ### Sys161 Config File
 
-The `sys161.conf` file is copied to `/home/osdev`. It will automatically be copied to `$WORKSPACE_DIR/os161/root`
-during the setup process. If a configuration file already exists inside the root directory, it will not be overridden.
+The `sys161.conf` file is populated inside `/home/osdev` like the other config files.
+It will automatically be copied to `$WORKSPACE_DIR/os161/root` during the setup process.
+If a configuration file already exists inside the root directory, it will not be ovewritten.

--- a/.devcontainer/config/sys161.conf
+++ b/.devcontainer/config/sys161.conf
@@ -1,0 +1,156 @@
+# Sample sys161.conf file
+#
+# This file tells System/161 what devices to use.
+#
+# There are 32 LAMEbus slots on the System/161 motherboard. There may
+# be only one bus controller card, and it must go in slot 31. Other
+# than that, you can put in whatever devices you want.
+#
+# The syntax is simple: one slot per line; the slot number goes first,
+# then the expansion card name, then any arguments. Some of the devices
+# have required arguments.
+#
+# The devices are:
+#
+#   mainboard The multiprocessor LAMEbus controller card. Must go in
+#             slot 31, and only in slot 31. Required argument
+#             "ramsize=NUMBER" specifies the amount of physical RAM in
+#             the system. This amount must be a multiple of the
+#             hardware page size (which is probably 4096 or 8192.) The
+#             maximum amount of RAM allowed is 16M; this restriction
+#             is meant as a sanity check and can be altered by
+#             recompiling System/161. The argument "cpus=NUMBER"
+#             selects the number of CPUs; the default is 1 and the
+#             maximum 32.
+#
+#   oldmainboard  The uniprocessor LAMEbus controller card, fully
+#             backwards compatible with OS/161 1.x. In general,
+#             uniprocessor kernels should nonetheless work on the
+#             multiprocessor mainboard; therefore this device will
+#             probably be removed in the future. Configuration is the
+#             same as the multiprocessor mainboard, except that the
+#             "cpus" argument is not accepted. The OS/161 1.x name
+#             "busctl" is an alias for "oldmainboard".
+#
+#   trace     The System/161 trace controller device. This can be used
+#             by software for various debugging purposes. You can have
+#             more than one trace card, but they all manipulate the 
+#             same internal state. No arguments.
+#
+#   timer     Countdown timer. The timer card also contains a real-time 
+#             clock and a small speaker for beeping. Most configurations
+#             will include at least one timer. No arguments. 
+#
+#   serial    Serial port. This is connected to the standard input and
+#             standard output of the System/161 process, and serves as
+#             the system console. Most configurations need this. There
+#             is no support at present for more than one serial port.
+#             No arguments.
+#
+#   screen    Full-screen memory-mapped text video card. This is 
+#             connected to the standard input and standard output of
+#             the System/161 process, and serves as the system console.
+#             There is no support at present for more than one screen.
+#             Likewise, at present you may not use "screen" and "serial"
+#             together. No arguments. NOTE: not presently implemented.
+#
+#   random    (Pseudo-)random number generator. This accesses the 
+#             randomizer state within System/161; thus, while you can
+#             add multiple random cards, they all return values from the
+#             same pseudorandom sequence. The random seed is set by 
+#             using either the "seed=NUMBER" argument, which sets the
+#             random seed to a specified value, or the "autoseed" 
+#             argument, which sets the random seed based on the host
+#             system clock. If neither argument is given or no random
+#             device is used, the seed is set to 0. Note that the seed
+#             affects various randomized behavior of the system as well
+#             as the values provided by the random device.
+#
+#   disk      Fixed disk. The options are as follows:
+#                 rpm=NUMBER         Set spin rate of disk.
+#                 sectors=NUMBER     Set disk size (legacy; see below).
+#                 file=PATH          Specify file to use as storage for disk.
+#                 paranoid           Set paranoid mode.
+#                 nodoom             Do not invoke the doom counter.
+#
+#             The "file=PATH" argument must be supplied. The size must be
+#             at least 128 sectors (64k), and the RPM setting must be a
+#             multiple of 60.
+#
+#             The "paranoid" argument, if given, causes fsync() to be 
+#             called on every disk write to make sure the data written
+#             reaches actual stable storage. This will make things very 
+#             slow.
+#
+#             The "nodoom" argument, if given, inhibits the doom counter
+#             for this disk. Otherwise, if the doom counter is enabled
+#             using the sys161 -D option, each write decrements the doom
+#             counter and the machine switches off when it reaches 0.
+#
+#             The "sectors" number, if given, sets the size of the disk.
+#             (Each sector is 512 bytes.) This option is only provided
+#             for compatibility with old configurations. As of System/161
+#             1.99.09, the size of the storage image file determines the
+#             size of the virtual disk. (One sector is used as a header.)
+#             If the configured "sectors" value does not match, a warning
+#             is printed. The "sectors" value is only used if the image
+#             file does not exist, in which case the file is created with
+#             the configured size. This behavior will be removed in a
+#             future version - use the disk161 tool to create disk images.
+#
+#             You can have as many disks as you want (until you run out
+#             of slots) but each should have a distinct file to use for
+#             storage. Most common setups will use two separate disks,
+#             one for filesystem storage and one for swapping.
+#
+#   nic       Network card. This allows communication among multiple
+#             simultaneously-running copies of System/161. The arguments
+#             are:
+#                 hub=PATH           Give the path to the hub socket.
+#                 hwaddr=NUMBER      Specify the hardware-level card address.
+#
+#             The hub socket path should be the argument supplied to the
+#             hub161 program. The default is ".sockets/hub".
+#
+#             The hardware address should be unique among the systems 
+#             connected to the same hub. It should be an integer between 
+#             1 and 65534. Values 0 and 65535 are reserved for special
+#             purposes. This argument is required.
+#
+#             NOTE: disable (comment out) nic devices if you aren't 
+#             actively using them, to avoid unnecessary overhead.
+#
+#   emufs     Emulator filesystem. This provides access *within* 
+#             System/161 to the filesystem that System/161 is running
+#             in. There is one optional argument, "dir=PATH". The path
+#             specified is used as the root of the filesystem provided
+#             by emufs. (Note that it is possible to access the real 
+#             parent of this root and thus any other directory; this
+#             argument does not restrict access.) The default path is
+#             ".", meaning System/161's own current directory.
+#
+
+#
+# Here is a suggested default configuration: 512k RAM, two disks.
+# The first is marked nodoom on the assumption that it will be a swap disk.
+# 5M is probably a good default disk size. Create the disk images with:
+#    disk161 create LHD0.img 5M
+#    disk161 create LHD1.img 5M
+#
+
+0	serial
+#0	screen
+
+1	emufs
+
+2	disk	rpm=7200	sectors=10240	file=LHD0.img   nodoom
+3	disk	rpm=7200	sectors=10240	file=LHD1.img
+
+#27	nic hwaddr=1
+
+28	random	autoseed
+29	timer
+30	trace
+31	mainboard  ramsize=524288  cpus=1
+#31	mainboard  ramsize=524288  cpus=2
+#31	mainboard  ramsize=524288  cpus=4

--- a/.devcontainer/config/update-bashrc.sh
+++ b/.devcontainer/config/update-bashrc.sh
@@ -1,5 +1,7 @@
 #/bin/bash
 
+#################################################################
+
 function add_line_to_bashrc() {
     # Accepts one argument which is the line to add to the .bashrc
     line_content=$1
@@ -9,3 +11,5 @@ function add_line_to_bashrc() {
 
 # Add path to OS161 tools
 add_line_to_bashrc "PATH=$OS161_DEPENDENCIES_DIR/tools/os161/bin:$OS161_DEPENDENCIES_DIR/tools/sys161/bin:$PATH"
+
+#################### ADD YOUR CHANGES BELOW #####################

--- a/.devcontainer/config/update-bashrc.sh
+++ b/.devcontainer/config/update-bashrc.sh
@@ -1,0 +1,11 @@
+#/bin/bash
+
+function add_line_to_bashrc() {
+    # Accepts one argument which is the line to add to the .bashrc
+    line_content=$1
+    echo "" >> ${HOME}/.bashrc
+    echo ${line_content} >> ${HOME}/.bashrc
+}
+
+# Add path to OS161 tools
+add_line_to_bashrc "PATH=$HOME/tools/os161/bin:$HOME/tools/sys161/bin:$PATH"

--- a/.devcontainer/config/update-bashrc.sh
+++ b/.devcontainer/config/update-bashrc.sh
@@ -8,4 +8,4 @@ function add_line_to_bashrc() {
 }
 
 # Add path to OS161 tools
-add_line_to_bashrc "PATH=$HOME/tools/os161/bin:$HOME/tools/sys161/bin:$PATH"
+add_line_to_bashrc "PATH=$OS161_DEPENDENCIES_DIR/tools/os161/bin:$OS161_DEPENDENCIES_DIR/tools/sys161/bin:$PATH"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,5 +11,5 @@ services:
       - os161_tools:/os161_dependencies:delegated
     command: sleep infinity
 volumes:
-  osdev_home:
+  os161_tools:
     

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,10 +8,7 @@ services:
       - type: bind
         source: ..
         target: /workspace
-      - type: bind
-        source: ${HOME}/.ssh
-        target: /home/osdev/.ssh
-      - osdev_home:/home/osdev:delegated
+      - os161_tools:/os161_dependencies:delegated
     command: sleep infinity
 volumes:
   osdev_home:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "label": "Setup Workspace",
-            "detail": "Compiles OS161 dependencies and configures the PATH variable",
+            "detail": "Compiles OS161 dependencies",
             "type": "shell",
             "command": "./setup.sh",
             "options": {

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # OS161 Devcontainer
 
 The OS161 devcontainer allows users to install their OS161 source code inside a docker
-container without the hassle of needing to install on their local host directly. The
-devcontainer has been tested on WSL2.
+container without the hassle of needing to install on their local host directly. It also
+provides additional features like VS Code tasks that streamline many of the redunant tasks
+that are common with developing OS161.
+
+The devcontainer has been tested on WSL2.
+
 
 ## How it works
+
 
 ### Overview
 
@@ -20,7 +25,8 @@ on your machine (with some limitations).
 
 Docker containers by themselves are incapable of having persisting storage. Once a container is stopped,
 the data inside is wiped. The devcontainer handles this issue by utilizing docker volumes, which
-allows persistent storage between multiple uses of the devcontainer. As is, there are three docker volumes:
+allows persistent storage between multiple uses of the devcontainer. As is, there are two docker volumes
+that the devcontainer uses:
 
 1. The first is a [bind mount](https://docs.docker.com/storage/bind-mounts/) on the `os161_devcontainer` directory,
 which synchronizes everything inside this directory between the devcontainer and the user's host machine. 
@@ -67,6 +73,20 @@ docker daemon.
 ```
 git clone https://github.com/DFriend01/os161_devcontainer.git
 ```
+
+> [!IMPORTANT]
+> If you are in Windows WSL, make sure that the devcontainer is cloned within the WSL network! If you
+> clone in the Windows partition, docker will not work as expected. You can tell if you are in the
+> Windows partition if:
+>
+> - The path outputed by the command `pwd` starts with `/mnt/c` if you are using the Ubuntu terminal
+> - The current directory starts with `C:` or `/c` if you are using the command prompt, git bash, or powershell
+>
+> It is recommended that you install [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install)
+> and use the Ubuntu profile when working in WSL. Also make sure that the starting directory is your home directory
+> `~`. If not, you will need to change the starting directory field for the Ubuntu profile to
+> `//wsl.localhost/<DISTRO NAME>/home/<USERNAME>`.
+> See the [windows terminal documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general#starting-directory).
 
 3. Clone your OS161 source code into the devcontainer:
 
@@ -147,8 +167,22 @@ Performing a full build of the kernel is mapped to `ctrl + shif + b`, which is a
 
 ### Where can I find my source code on my host machine after developing in the devcontainer?
 
-Your work will be saved in the directory `os161_devcontainer/os161`. Everything inside `$WORKSPACE_DIR`
-inside the devcontainer is synced to `os161_devcontainer/os161`.
+Your work will be saved in the directory `os161_devcontainer/os161`. Everything inside the `$WORKSPACE_DIR`
+directory in the devcontainer is synced to `os161_devcontainer/os161` on your local host.
+
+### Where is my OS161 code stored in the devcontainer?
+
+OS161 source code is stored in `$WORKSPACE_DIR/os161/src`. If you changed directories and do not remember
+where the source code is, then change directories back to the workspace:
+
+```bash
+cd $WORKSPACE_DIR
+```
+
+### Where are the OS161 tools stored?
+
+The OS161 tools are stored in `$OS161_DEPENDENCIES_DIR`. This directory is persisted in a docker volume,
+so any changes made to the tools (i.e. if you desire to add symbolic links), those are also persisted.
 
 ### Will I need to run the setup script/task every time I start the devcontainer?
 
@@ -158,7 +192,7 @@ No! You only need to run it when:
 - You delete the docker named volume that contains the compiled OS161 tools; OR
 - You delete your `root` directory and/or your `sys161.conf` file
 
-The script does checks to make sure whether each setup step inside the script is necessary or not,
+The script does check to make sure whether each setup step inside the script is necessary or not,
 so there is no harm in running it again if you want to.
 
 ### How can I add my own dotfiles to the devcontainer?

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ Changes made in the devcontainer are observed in the local host, and vice versa.
 is mapped between the location of `os161_devcontainer` on your host machine, and the directory
 specified by the environment variable `$WORKSPACE_DIR` inside the devcontainer.
 
-2. The second is another bind mount that maps `~/.ssh` on the local host to `~/.ssh` in the devcontainer.
-
-3. The third is a [named volume](https://docs.docker.com/storage/volumes/), which is used on the home directory
-for the `osdev` user inside the devcontainer. Unlike the first volume, this volume is stored and is handled by docker.
+2. The second is a [named volume](https://docs.docker.com/storage/volumes/), which is used to persist the
+directory specified by the environment variable `$OS161_DEPENDENCIES_DIR` which persists the compiled OS161 tools to avoid 
+recompiling upon each rebuild of the docker container.
 
 > [!WARNING]
-> Any data that is not stored in either `$WORKSPACE_DIR` or `/home/osdev` will be wiped out upon
-> stopping the container. If you want to store data in another location, you will need to edit
-> the `docker-compose.yml` file to add another volume and rebuild the container.
+> Any data that is not stored in `$WORKSPACE_DIR` or any of its subdirectories will be wiped out upon
+> stopping the container. If you want to store data in another location inside the devcontainer,
+> you will need to edit the `docker-compose.yml` file to add another volume and rebuild the container.
+> Consult the [docker documentation](https://docs.docker.com/storage/volumes/#use-a-volume-with-docker-compose).
 
 ## Prerequisites
 
@@ -121,17 +121,15 @@ cd $WORKSPACE_DIR/scripts
 ./setup.sh
 ```
 
-6. Source the `.bashrc` file or reopen a new terminal inside the devcontainer. Confirm that the dependencies installed correctly by observing `which sys161` outputting
-a valid path. Also take a look at `~/tools`.
+Alternativly, you can run the `Setup Workspace` VS Code task. See the section on
+[VS Code tasks](#vs-code-tasks).
 
-```
-source /home/osdev/.bashrc
-```
+6. Confirm that the dependencies installed correctly by observing `which sys161` outputting
+a valid path. Also take a look at `$OS161_DEPENDENCIES_DIR/tools`.
 
-
-7. Build your kernel. The setup script automatically fetches a configuration script `sys161.conf` located in
-`$WORKSPACE_DIR/os161`. Either copy it into `$WORKSPACE_DIR/os161/root` after building, or use your own
-configuration file if you have one already.
+7. Build your kernel. You can either do it yourself following the
+[instructions on the course website](https://people.ece.ubc.ca/~os161/os161-site/build-os161.html)
+or run the [build task](#vs-code-tasks).
 
 ## VS Code Tasks
 
@@ -143,7 +141,37 @@ Run a VS Code task by:
 - Selecting `Tasks: Run Task`
 - Selecting the desired task to run
 
-> [!NOTE]
-> When building for the first time, sometimes the VS Code tasks that do the build process won't work until
-> you build for the first time. The reason as of right now is unknown. If you encounter any issues, just
-> build manually in the CLI and try the tasks later.
+Performing a full build of the kernel is mapped to `ctrl + shif + b`, which is also the `Build` task.
+
+## FAQs
+
+### Where can I find my source code on my host machine after developing in the devcontainer?
+
+Your work will be saved in the directory `os161_devcontainer/os161`. Everything inside `$WORKSPACE_DIR`
+inside the devcontainer is synced to `os161_devcontainer/os161`.
+
+### Will I need to run the setup script/task every time I start the devcontainer?
+
+No! You only need to run it when:
+
+- You are setting up the devcontainer for the first time; OR
+- You delete the docker named volume that contains the compiled OS161 tools; OR
+- You delete your `root` directory and/or your `sys161.conf` file
+
+The script does checks to make sure whether each setup step inside the script is necessary or not,
+so there is no harm in running it again if you want to.
+
+### How can I add my own dotfiles to the devcontainer?
+
+See the [documentation on configuration](.devcontainer/config/README.md).
+
+### How can I run VS Code commands and tasks?
+
+`ctrl + shift + p` opens the command palette. Search your desired VS Code command and execute it.
+If you want to execute a task, select the `Tasks: Run Task` VS Code command and select the desired
+task.
+
+### How can I add my own VS Code tasks?
+
+Add your own tasks to the [tasks configuration file](.vscode/tasks.json). See the existing tasks
+as examples.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,7 +11,7 @@ function install() {
 
     # Probably should parameterize the darwin script to install in some specified directory
     # but this works for now
-    mv ~/tools $OS161_DEPENDENCIES_DIR
+    sudo mv ~/tools $OS161_DEPENDENCIES_DIR
 
     cd $prev_dir
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,13 +9,7 @@ function install() {
     prev_dir=$(pwd)
     cd $WORKSPACE_DIR/scripts
     bash ./cs161-ubuntu-darwin.sh
-
     cd $prev_dir
-
-    echo "Fetching default sys161.conf file from the ECE server..."
-    wget people.ece.ubc.ca/~os161/download/sys161.conf.sample -O ${WORKSPACE_DIR}/os161/sys161.conf
-    echo "You may copy sys161.conf (or use your own) located in ${WORKSPACE_DIR}/os161 into your root directory with:"
-    echo -e "\tcp \$WORKSPACE_DIR/os161/sys161.conf \$WORKSPACE_DIR/os161/root"
 }
 
 if [[ -d $HOME/tools ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,9 +12,6 @@ function install() {
 
     cd $prev_dir
 
-    echo "Adding OS161 dependencies to PATH..."
-    echo "PATH=$HOME/tools/os161/bin:$HOME/tools/sys161/bin:$PATH >> $HOME/.bashrc"
-
     echo "Fetching default sys161.conf file from the ECE server..."
     wget people.ece.ubc.ca/~os161/download/sys161.conf.sample -O ${WORKSPACE_DIR}/os161/sys161.conf
     echo "You may copy sys161.conf (or use your own) located in ${WORKSPACE_DIR}/os161 into your root directory with:"
@@ -27,5 +24,4 @@ else
     install
 fi
 
-source $HOME/.bashrc
 echo "Done setup!"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,11 +8,16 @@ function install() {
     prev_dir=$(pwd)
     cd $WORKSPACE_DIR/scripts
     bash ./cs161-ubuntu-darwin.sh
+
+    # Probably should parameterize the darwin script to install in some specified directory
+    # but this works for now
+    mv ~/tools $OS161_DEPENDENCIES_DIR
+
     cd $prev_dir
 }
 
-if [[ -d $HOME/tools ]]; then
-    echo "~/tools already exists. Delete ~/tools if rebuilding is desired. Skipping build..."
+if [[ -d $OS161_DEPENDENCIES_DIR/tools ]]; then
+    echo "${OS161_DEPENDENCIES_DIR}/tools already exists. Delete it if rebuilding is desired. Skipping build..."
 else
     install
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,3 @@
-
 #/bin/bash
 
 # This script only needs to be ran once even after rebuilding (as long as the osdev_home volume isn't deleted)
@@ -16,6 +15,17 @@ if [[ -d $HOME/tools ]]; then
     echo "~/tools already exists. Delete ~/tools if rebuilding is desired. Skipping build..."
 else
     install
+fi
+
+if [[ ! -d ${WORKSPACE_DIR}/os161/root ]]; then
+    mkdir -p ${WORKSPACE_DIR}/os161/root
+fi
+
+if [[ ! -f ${WORKSPACE_DIR}/os161/root/sys161.conf ]]; then
+    echo "sys161.conf does not exist in root directory. Adding config file..."
+    cp ${HOME}/sys161.conf ${WORKSPACE_DIR}/os161/root
+else
+    echo "sy161.conf already exists"
 fi
 
 echo "Done setup!"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,13 +17,16 @@ function install() {
 }
 
 if [[ -d $OS161_DEPENDENCIES_DIR/tools ]]; then
-    echo "${OS161_DEPENDENCIES_DIR}/tools already exists. Delete it if rebuilding is desired. Skipping build..."
+    echo "${OS161_DEPENDENCIES_DIR}/tools already exists. Delete the tools directory " + \
+         "if rebuilding is desired. Skipping build..."
 else
     install
 fi
 
 if [[ ! -d ${WORKSPACE_DIR}/os161/root ]]; then
     mkdir -p ${WORKSPACE_DIR}/os161/root
+else
+    echo "root directory already exists"
 fi
 
 if [[ ! -f ${WORKSPACE_DIR}/os161/root/sys161.conf ]]; then


### PR DESCRIPTION
### Updates
- Change docker volumes:
  - No longer using a docker volume in `/home/osdev`
  - New docker volume at `/os161_dependencies` that contain the tools directory
- Change configuration options:
  - Add `.devcontainer/config` directory to allow users to add their own dotfiles and integrated into Dockerfile
- Fixed bug with VS Code tasks where build tasks didn't work until first manual build