### PR TITLE
Remove debugger comments in code workspace file

### DIFF
--- a/os161.code-workspace
+++ b/os161.code-workspace
@@ -76,10 +76,6 @@
             // JSON Reference: https://code.visualstudio.com/docs/cpp/launch-json-reference
 
             // Launch configuration to debug OS161. Remember to build first with CTRL + SHIFT + B.
-            // There is an issue with this configuration where it will break in start.S, but it won't
-            // step into the C code for kmain unless you put a breakpoint there (or back and forth
-            // between C code and mips in general). If you see this, maybe you can try and figure that
-            // out and make a PR <3
             {
                 "name": "Run OS161 (Debug)",
                 "type": "cppdbg",


### PR DESCRIPTION
Turns out you need to step into `jal kmain` in `start.S` to step into kmain in `main.c`